### PR TITLE
removing config volumes as they are not used in this image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -104,4 +104,3 @@ COPY /root /
 
 # ports and volumes
 EXPOSE 4822
-VOLUME /config

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -104,4 +104,3 @@ COPY /root /
 
 # ports and volumes
 EXPOSE 4822
-VOLUME /config

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -104,4 +104,3 @@ COPY /root /
 
 # ports and volumes
 EXPOSE 4822
-VOLUME /config


### PR DESCRIPTION
This image should never need a bound volume unless the user decides to try the screen capture features. 