### PR TITLE
revert to 1.0.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM lsiobase/ubuntu:bionic as builder
 
-ARG GUACD_VERSION=1.1.0
+ARG GUACD_VERSION=1.0.0
 
 COPY /buildroot /
 
@@ -11,7 +11,6 @@ RUN \
 	autoconf \
 	automake \
 	checkinstall \
-	freerdp2-dev \
 	gcc-6 \
 	git \
 	libavcodec-dev \
@@ -69,7 +68,7 @@ FROM lsiobase/ubuntu:bionic
 # set version label
 ARG BUILD_DATE
 ARG VERSION
-ARG GUACD_VERSION=1.1.0
+ARG GUACD_VERSION=1.0.0
 LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
 LABEL maintainer="Thelamer"
 
@@ -87,11 +86,14 @@ RUN \
 	fonts-dejavu \
 	ghostscript \
 	libcairo2 \
-	libfreerdp2-2 \
+	libfreerdp-plugins-standard \
 	xfonts-terminus && \
  apt-get install -qy --no-install-recommends \
 	$(cat /tmp/out/DEPENDENCIES) && \
  echo "**** clean up ****" && \
+ mv \
+	/usr/lib/freerdp/* \
+	/usr/lib/x86_64-linux-gnu/freerdp && \
  rm -rf \
 	/tmp/* \
 	/var/lib/apt/lists/* \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -1,6 +1,6 @@
 FROM lsiobase/ubuntu:arm64v8-bionic as builder
 
-ARG GUACD_VERSION=1.1.0
+ARG GUACD_VERSION=1.0.0
 
 COPY /buildroot /
 
@@ -11,7 +11,6 @@ RUN \
 	autoconf \
 	automake \
 	checkinstall \
-	freerdp2-dev \
 	gcc-6 \
 	git \
 	libavcodec-dev \
@@ -55,7 +54,7 @@ RUN \
 	-D \
 	--nodoc \
 	--pkgname guacd \
-	--pkgversion "${GUACD_VERSION}" \
+	--pkgversion ${GUACD_VERSION} \
 	--pakdir /tmp \
 	--exclude "/usr/share/man","/usr/include","/etc" && \
  mkdir -p /tmp/out && \
@@ -69,7 +68,7 @@ FROM lsiobase/ubuntu:arm64v8-bionic
 # set version label
 ARG BUILD_DATE
 ARG VERSION
-ARG GUACD_VERSION=1.1.0
+ARG GUACD_VERSION=1.0.0
 LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
 LABEL maintainer="Thelamer"
 
@@ -87,11 +86,14 @@ RUN \
 	fonts-dejavu \
 	ghostscript \
 	libcairo2 \
-	libfreerdp2-2 \
+	libfreerdp-plugins-standard \
 	xfonts-terminus && \
  apt-get install -qy --no-install-recommends \
 	$(cat /tmp/out/DEPENDENCIES) && \
  echo "**** clean up ****" && \
+ mv \
+	/usr/lib/freerdp/* \
+	/usr/lib/aarch64-linux-gnu/freerdp && \
  rm -rf \
 	/tmp/* \
 	/var/lib/apt/lists/* \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -1,6 +1,6 @@
 FROM lsiobase/ubuntu:arm32v7-bionic as builder
 
-ARG GUACD_VERSION=1.1.0
+ARG GUACD_VERSION=1.0.0
 
 COPY /buildroot /
 
@@ -11,7 +11,6 @@ RUN \
 	autoconf \
 	automake \
 	checkinstall \
-	freerdp2-dev \
 	gcc-6 \
 	git \
 	libavcodec-dev \
@@ -55,7 +54,7 @@ RUN \
 	-D \
 	--nodoc \
 	--pkgname guacd \
-	--pkgversion "${GUACD_VERSION}" \
+	--pkgversion ${GUACD_VERSION} \
 	--pakdir /tmp \
 	--exclude "/usr/share/man","/usr/include","/etc" && \
  mkdir -p /tmp/out && \
@@ -69,7 +68,7 @@ FROM lsiobase/ubuntu:arm32v7-bionic
 # set version label
 ARG BUILD_DATE
 ARG VERSION
-ARG GUACD_VERSION=1.1.0
+ARG GUACD_VERSION=1.0.0
 LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
 LABEL maintainer="Thelamer"
 
@@ -87,11 +86,14 @@ RUN \
 	fonts-dejavu \
 	ghostscript \
 	libcairo2 \
-	libfreerdp2-2 \
+	libfreerdp-plugins-standard \
 	xfonts-terminus && \
  apt-get install -qy --no-install-recommends \
 	$(cat /tmp/out/DEPENDENCIES) && \
  echo "**** clean up ****" && \
+ mv \
+	/usr/lib/freerdp/* \
+	/usr/lib/arm-linux-gnueabihf/freerdp && \
  rm -rf \
 	/tmp/* \
 	/var/lib/apt/lists/* \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -103,7 +103,7 @@ pipeline {
       steps{
         script{
           env.EXT_RELEASE = sh(
-            script: ''' echo 1.1.0 ''',
+            script: ''' echo 1.0.0 ''',
             returnStdout: true).trim()
             env.RELEASE_LINK = 'custom_command'
         }

--- a/jenkins-vars.yml
+++ b/jenkins-vars.yml
@@ -3,7 +3,7 @@
 # jenkins variables
 project_name: docker-guacd
 external_type: na
-custom_version_command: "echo 1.1.0"
+custom_version_command: "echo 1.0.0"
 release_type: stable
 release_tag: latest
 ls_branch: master


### PR DESCRIPTION
I have found specifically that version 1.1.0 of the guacd client does not work with the latest version of Windows 10 remote desktop. 
There is not enough in the logs to go off of, but I can confirm with 100% certainty that it works with 1.0.0 for both my custom frontend stuff and the default guacamole client hooked into postgres/,mysql. 

Given this is such a core functionality we need to revert. 