### PR TITLE
adding terminus font for ssh rendering support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -90,7 +90,8 @@ RUN \
 	libvncserver \
 	libwebp \
 	libwebsockets \
-	pango && \
+	pango \
+	terminus-font && \
  apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing \
 	ossp-uuid && \
  echo "**** cleanup ****" && \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -90,7 +90,8 @@ RUN \
 	libvncserver \
 	libwebp \
 	libwebsockets \
-	pango && \
+	pango \
+	terminus-font && \
  apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing \
 	ossp-uuid && \
  echo "**** cleanup ****" && \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -90,7 +90,8 @@ RUN \
 	libvncserver \
 	libwebp \
 	libwebsockets \
-	pango && \
+	pango \
+	terminus-font && \
  apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing \
 	ossp-uuid && \
  echo "**** cleanup ****" && \

--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **15.05.21:** - Add terminus font for SSH support.
 * **08.05.21:** - Bump to 1.3.0, rebase to Alpine.
 * **27.07.20:** - Bump to 1.2.0.
 * **17.04.20:** - Bump back 1.1.0, rebase to focal

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -30,6 +30,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "15.05.21:", desc: "Add terminus font for SSH support." }
   - { date: "08.05.21:", desc: "Bump to 1.3.0, rebase to Alpine." }
   - { date: "27.07.20:", desc: "Bump to 1.2.0." }
   - { date: "17.04.20:", desc: "Bump back 1.1.0, rebase to focal" }


### PR DESCRIPTION
Missed this in the rebase to alpine, you need some system level font in order for guacd to render in the ssh session it sends to the client. 