### PR TITLE
Patch 1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # guacamole builder
-FROM ghcr.io/linuxserver/baseimage-alpine:3.13 as guacbuilder
+FROM ghcr.io/linuxserver/baseimage-alpine:3.15 as guacbuilder
 
-ARG GUACD_VERSION=1.3.0
+ARG GUACD_VERSION=1.4.0
 
 RUN \
  echo "**** install build deps ****" && \
@@ -37,6 +37,9 @@ RUN \
 	http://apache.org/dyn/closer.cgi?action=download\&filename=guacamole/${GUACD_VERSION}/source/guacamole-server-${GUACD_VERSION}.tar.gz \
 	-O guac.tar.gz && \
  tar -xf guac.tar.gz && \
+  wget \
+	https://raw.githubusercontent.com/apache/guacamole-server/master/src/guacenc/ffmpeg-compat.c \
+	-O /tmp/guac/guacamole-server-${GUACD_VERSION}/src/guacenc/ffmpeg-compat.c && \
  cd guacamole-server-${GUACD_VERSION} && \
  ./configure \
 	--prefix=/usr \

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN \
 	http://apache.org/dyn/closer.cgi?action=download\&filename=guacamole/${GUACD_VERSION}/source/guacamole-server-${GUACD_VERSION}.tar.gz \
 	-O guac.tar.gz && \
  tar -xf guac.tar.gz && \
-  wget \
+ wget \ 
 	https://raw.githubusercontent.com/apache/guacamole-server/master/src/guacenc/ffmpeg-compat.c \
 	-O /tmp/guac/guacamole-server-${GUACD_VERSION}/src/guacenc/ffmpeg-compat.c && \
  cd guacamole-server-${GUACD_VERSION} && \
@@ -66,7 +66,7 @@ RUN \
  make DESTDIR=/buildout install
 
 # runtime stage
-FROM ghcr.io/linuxserver/baseimage-alpine:3.13
+FROM ghcr.io/linuxserver/baseimage-alpine:3.15
 
 # set version label
 ARG BUILD_DATE

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -94,7 +94,8 @@ RUN \
 	libvncserver \
 	libwebp \
 	libwebsockets \
-	pango && \
+	pango \
+  terminus-font && \
  apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing \
 	ossp-uuid && \
  echo "**** cleanup ****" && \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -1,7 +1,7 @@
 # guacamole builder
-FROM ghcr.io/linuxserver/baseimage-alpine:arm64v8-3.13 as guacbuilder
+FROM ghcr.io/linuxserver/baseimage-alpine:arm64v8-3.15 as guacbuilder
 
-ARG GUACD_VERSION=1.3.0
+ARG GUACD_VERSION=1.4.0
 
 RUN \
  echo "**** install build deps ****" && \
@@ -37,6 +37,9 @@ RUN \
 	http://apache.org/dyn/closer.cgi?action=download\&filename=guacamole/${GUACD_VERSION}/source/guacamole-server-${GUACD_VERSION}.tar.gz \
 	-O guac.tar.gz && \
  tar -xf guac.tar.gz && \
+ wget \ 
+	https://raw.githubusercontent.com/apache/guacamole-server/master/src/guacenc/ffmpeg-compat.c \
+	-O /tmp/guac/guacamole-server-${GUACD_VERSION}/src/guacenc/ffmpeg-compat.c && \
  cd guacamole-server-${GUACD_VERSION} && \
  ./configure \
 	--prefix=/usr \
@@ -63,7 +66,7 @@ RUN \
  make DESTDIR=/buildout install
 
 # runtime stage
-FROM ghcr.io/linuxserver/baseimage-alpine:arm64v8-3.13
+FROM ghcr.io/linuxserver/baseimage-alpine:arm64v8-3.15
 
 # set version label
 ARG BUILD_DATE
@@ -91,8 +94,7 @@ RUN \
 	libvncserver \
 	libwebp \
 	libwebsockets \
-	pango \
-	terminus-font && \
+	pango && \
  apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing \
 	ossp-uuid && \
  echo "**** cleanup ****" && \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -94,7 +94,8 @@ RUN \
 	libvncserver \
 	libwebp \
 	libwebsockets \
-	pango && \
+	pango \
+  terminus-font && \
  apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing \
 	ossp-uuid && \
  echo "**** cleanup ****" && \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -1,7 +1,7 @@
 # guacamole builder
-FROM ghcr.io/linuxserver/baseimage-alpine:arm32v7-3.13 as guacbuilder
+FROM ghcr.io/linuxserver/baseimage-alpine:arm32v7-3.15 as guacbuilder
 
-ARG GUACD_VERSION=1.3.0
+ARG GUACD_VERSION=1.4.0
 
 RUN \
  echo "**** install build deps ****" && \
@@ -37,6 +37,9 @@ RUN \
 	http://apache.org/dyn/closer.cgi?action=download\&filename=guacamole/${GUACD_VERSION}/source/guacamole-server-${GUACD_VERSION}.tar.gz \
 	-O guac.tar.gz && \
  tar -xf guac.tar.gz && \
+ wget \ 
+	https://raw.githubusercontent.com/apache/guacamole-server/master/src/guacenc/ffmpeg-compat.c \
+	-O /tmp/guac/guacamole-server-${GUACD_VERSION}/src/guacenc/ffmpeg-compat.c && \
  cd guacamole-server-${GUACD_VERSION} && \
  ./configure \
 	--prefix=/usr \
@@ -63,7 +66,7 @@ RUN \
  make DESTDIR=/buildout install
 
 # runtime stage
-FROM ghcr.io/linuxserver/baseimage-alpine:arm32v7-3.13
+FROM ghcr.io/linuxserver/baseimage-alpine:arm32v7-3.15
 
 # set version label
 ARG BUILD_DATE
@@ -91,8 +94,7 @@ RUN \
 	libvncserver \
 	libwebp \
 	libwebsockets \
-	pango \
-	terminus-font && \
+	pango && \
  apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing \
 	ossp-uuid && \
  echo "**** cleanup ****" && \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -104,7 +104,7 @@ pipeline {
       steps{
         script{
           env.EXT_RELEASE = sh(
-            script: ''' echo 1.3.0 ''',
+            script: ''' echo 1.4.0 ''',
             returnStdout: true).trim()
             env.RELEASE_LINK = 'custom_command'
         }

--- a/jenkins-vars.yml
+++ b/jenkins-vars.yml
@@ -3,7 +3,7 @@
 # jenkins variables
 project_name: docker-guacd
 external_type: na
-custom_version_command: "echo 1.3.0"
+custom_version_command: "echo 1.4.0"
 release_type: stable
 release_tag: latest
 ls_branch: master


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-guacd/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
Update to alpine 3.15 and guacamole 1.4.0.

Guacamole 1.4.0 would not build with Alpine 3.15, because Alpine 3.15 comes with ffmpeg 4.4.1, which has deprecated the use of av_init_packet(), which is called in guacamole-server/src/guacenc/ffpmpeg_compat.c.
The master branch of guacamole-server is fixed: https://github.com/apache/guacamole-server/commit/bc6b5cef25cb2c66cb4e0e96df6d2639a61a197a but not reflected in the package available for download at https://guacamole.apache.org/releases/1.4.0/

Downloading ffmpeg_compat.c after downloading guacamole-server-1.4.0 but before building it allows guacamole to be built without error.

## Benefits of this PR and context:
Benefits for users is a more recent Alpine base, and a more recent Guacamole server.

## How Has This Been Tested?
Image has been built and test for the amd64 arch.
Not tested for arm64 and armhf, but the changes should not prevent building.

## Source / References:
Listed in the description of the change.
